### PR TITLE
airror-flasher: fix install instructions

### DIFF
--- a/sensor_community_airrohr_workshop.md
+++ b/sensor_community_airrohr_workshop.md
@@ -121,9 +121,10 @@ git clone https://github.com/opendata-stuttgart/airrohr-firmware-flasher
 cd airrohr-firmware-flasher
 python -m venv airrohr_venv             # Python Virtual Env anlegen
 source ./airrohr_venv/bin/activate      # Python Virtual Env aktivieren
-echo Versionen von pyqt5-sip und pyqt5 entfernen:
+# Versionen von pyinstaller, pyqt5-sip und pyqt5 entfernen:
 vim requirements.txt
 pip3 install -r requirements.txt        # Deps installieren
+make gui/mainwindow.py                  # GUI Generieren
 ```
 
 Tool starten


### PR DESCRIPTION
Previous instructions did not "reliably" get the installer working.

PyInstaller does not install in the specified version on Python 3.11, so also remove the version requirement from there.

The GUI also does not work without running make.

Only the GUI is needed, so don't make everything, otherwise it would need extra dependencies for translations of the GUI (`lrelease` from `qt5-tools`)